### PR TITLE
Update API for Enums{EMode, EInterpolationType}

### DIFF
--- a/FbxReadWriter.py
+++ b/FbxReadWriter.py
@@ -40,15 +40,15 @@ class FbxReadWrite(object):
         """
         lKeyIndex = 0
         lTime = FbxTime()
-        lTime.SetGlobalTimeMode(FbxTime.eFrames60) # Set to fps=60
+        lTime.SetGlobalTimeMode(FbxTime.EMode.eFrames60) # Set to fps=60
         data = np.squeeze(data)
 
         lCurve.KeyModifyBegin()
         for i in range(data.shape[0]):
-            lTime.SetFrame(i, FbxTime.eFrames60)
+            lTime.SetFrame(i, FbxTime.EMode.eFrames60)
             lKeyIndex = lCurve.KeyAdd(lTime)[0]
             lCurve.KeySetValue(lKeyIndex, data[i])
-            lCurve.KeySetInterpolation(lKeyIndex, FbxAnimCurveDef.eInterpolationCubic)
+            lCurve.KeySetInterpolation(lKeyIndex, FbxAnimCurveDef.EInterpolationType.eInterpolationCubic)
         lCurve.KeyModifyEnd()
 
     def addAnimation(self, pkl_filename:str, smpl_params:Dict, verbose:bool = False):
@@ -58,7 +58,7 @@ class FbxReadWrite(object):
         lGlobalSettings = lScene.GetGlobalSettings()
         if verbose==True:
             print ("Before time mode:{}".format(lGlobalSettings.GetTimeMode()))
-        lGlobalSettings.SetTimeMode(FbxTime.eFrames60)
+        lGlobalSettings.SetTimeMode(FbxTime.EMode.eFrames60)
         if verbose==True:
             print ("After time mode:{}".format(lScene.GetGlobalSettings().GetTimeMode()))
 


### PR DESCRIPTION
Seems like due to updates to the FBX (Python) SDK, the API has changed and causes segmentation [fault](https://github.com/GuyTevet/motion-diffusion-model/issues/5#issuecomment-1288039652) [errors](https://github.com/GuyTevet/motion-diffusion-model/issues/5#issuecomment-1603323666)

Changes were made for the Enums according to the [docs](http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=files/GUID-363E55D8-6EDB-40F8-8F58-E42F8D525D3D.htm,topicNumber=d30e12447) [here](http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=files/GUID-363E55D8-6EDB-40F8-8F58-E42F8D525D3D.htm,topicNumber=d30e12447)

Tested using the following versions:
```
Package    Version
---------- --------
Python     3.10.11
fbx SDK    2020.3.4
numpy      1.25.0
packaging  23.1
pip        23.1.2
ply        3.11
scipy      1.10.1
setuptools 68.0.0
sip        6.6.2
toml       0.10.2
tqdm       4.65.0
wheel      0.38.4
```